### PR TITLE
[MDA ICHRA CONNECT]: Fix url links, csv validator content, datetime formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.quarto/
 /_site/
 # /docs/
+*.quarto_ipynb
 
 .venv

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -42,7 +42,7 @@ website:
       - section: "**CSV**"
         contents:
           - text: "Implementation Guide"
-            href: csv/csv_implementation_guide.qmd
+            href: csv/csv_implementation_guide.html
           - section: "File Specifications"
             contents:
               - csv/file_spec/file_spec.qmd

--- a/csv/file_spec/inbound_enrollment_spec.csv
+++ b/csv/file_spec/inbound_enrollment_spec.csv
@@ -27,7 +27,7 @@ enrollment.renewal_type,Enum,Renewal Type,Valid enum value (ACTIVE/PASSIVE),,,N
 enrollment.external_policy_id,String,Unique identifier for the policy (coming from the partner),,,,Y
 enrollment.external_subscriber_id,String,,,,,N
 enrollment.cancel_overlapping_eligibility,Boolean,Term or cancel existing eligibility if it overlaps and prefer new one,Valid Boolean String,FALSE,,N
-enrollment.date_signed,String,Time when broker or consumer submitted their enrollment,ISO Format,2011-11-04 00:05:23.283+00:00,,Y
+enrollment.date_signed,String,Time when broker or consumer submitted their enrollment,%Y-%m-%d %H:%M:%S.%f%z ISO Format,2011-11-04 00:05:23.283+00:00,,Y
 enrollment.qualifying_event,Enum,Enrollment Qualifying Event,,,,Y if enrollee.change_type is not CANCELLATION or TERMINATION
 enrollment.qualifying_event_date,String,Enrollment Qualifying Event Date,YYYY-MM-DD,1996-01-01,,Y if qualifying_event provided
 enrollment.application_id,String,The ID of the application,,,,N

--- a/csv_validator.qmd
+++ b/csv_validator.qmd
@@ -289,8 +289,17 @@ execute:
     return errors;
   }
 
-  document.getElementById("csvFileInput").addEventListener("change", function (event) {
-    const file = event.target.files[0];
+  document.getElementById("validateButton").addEventListener("click", function () {
+    const fileInput = document.getElementById("csvFileInput");
+    const textarea = document.getElementById("csvTextarea");
+    const file = fileInput.files[0];
+    const textContent = textarea.value.trim();
+
+    if ((file && textContent) || (!file && !textContent)) {
+      displayResults(["Please provide either a CSV file or paste CSV content, not both."]);
+      return;
+    }
+
     if (file) {
       const reader = new FileReader();
       reader.onload = function (e) {
@@ -298,10 +307,8 @@ execute:
         displayResults(errors);
       };
       reader.readAsText(file);
+      return;
     }
-  });
-
-  document.getElementById("validateButton").addEventListener("click", function () {
     const content = document.getElementById("csvTextarea").value;
     const errors = validateCSV(content);
     displayResults(errors);

--- a/integrating_with_oscar.qmd
+++ b/integrating_with_oscar.qmd
@@ -7,47 +7,47 @@ Oscar supports both the EDI and CSV integration standards. We expect ICHRA admin
 ### Oscar Supported Integration Standards
 
 * [EDI Enrollment and Payment Data Integration](edi_implementation_guide.qmd)
-  * 834 Enrollment EDI  
-  * 820 Payment EDI  
-* [CSV Enrollment and Payment Data Integration](csv_implementation_guide.qmd)  
+  * 834 Enrollment EDI
+  * 820 Payment EDI
+* [CSV Enrollment and Payment Data Integration](csv/csv_implementation_guide.qmd)
   * CSV Reconciliation File & Processes
 
 ## Standard Timeline {#standard-timeline}
 
 Timelines are based on Oscar standard ICHRA administrator integration as defined below. Any changes, updates, or deviations may incur additional time to launch. Timelines start when Oscar and platform agree to proceed with an integration.
 
-* 2-3 weeks: File spec & implementation alignment; security assessment; SFTP setup  
-* 2-3 weeks: Build & integration configuration  
+* 2-3 weeks: File spec & implementation alignment; security assessment; SFTP setup
+* 2-3 weeks: Build & integration configuration
 * 2-3 weeks: Data integration testing
 
 ## Administrator Onboarding
 
-To set up an integration, Oscar requires the following from all administrator partners: 
+To set up an integration, Oscar requires the following from all administrator partners:
 
-* Signature of an NDA and standard vendor and/or producer agreement with BAA  
-* Security assessment for SFTP setup, providing **one** of the following:  
-  * SOC 2 Type 2 assessment report conducted within the last 36 months  
-  * HITRUST certificate  
-  * ISO 27001 assessment report  
+* Signature of an NDA and standard vendor and/or producer agreement with BAA
+* Security assessment for SFTP setup, providing **one** of the following:
+  * SOC 2 Type 2 assessment report conducted within the last 36 months
+  * HITRUST certificate
+  * ISO 27001 assessment report
   * Completed Oscar Vendor Security Assessment Questionnaire
 * SFTP setup
 
 ## FAQs
 
 #### What types of integrations does Oscar support for ICHRA administrators?
-For off-exchange ICHRA enrollments, Oscar currently supports two main methods of integration for enrollment and payment data: 
+For off-exchange ICHRA enrollments, Oscar currently supports two main methods of integration for enrollment and payment data:
 
-1. Dual-file EDI Integration  
-    * Enrollment: Daily batch 834 EDI \- inbound and outbound  
-        * TA1/999 Acknowledgement & Error response  
-        * CSV Reconciliation  
-    * Payment: Batch 820 EDI for payment remittance with ACH direct deposit  
-  For both the [enrollment 834 EDI](CMS_X12_834_Companion_Guide_v7.2.pdf){target="_blank"} and [820 EDI implementation](edi_implementation_guide.qmd), we use the CMS implementation standards, with a modification to the 834 EDI standard to include employer information in the 2100D employer loop.   
-    
-1. Combined File CSV Integration  
-    * Single combined enrollment & payment CSV file \- daily batch (Oscar Inbound)  
-        * Payment instrument details (bank account information) is passed to Oscar with the enrollment data and binder payments and auto-payments are automatically enabled.  
-* Oscar CSV Acknowledgement file \- daily (Oscar Outbound)  
+1. Dual-file EDI Integration
+    * Enrollment: Daily batch 834 EDI \- inbound and outbound
+        * TA1/999 Acknowledgement & Error response
+        * CSV Reconciliation
+    * Payment: Batch 820 EDI for payment remittance with ACH direct deposit
+  For both the [enrollment 834 EDI](CMS_X12_834_Companion_Guide_v7.2.pdf){target="_blank"} and [820 EDI implementation](edi_implementation_guide.qmd), we use the CMS implementation standards, with a modification to the 834 EDI standard to include employer information in the 2100D employer loop.
+
+1. Combined File CSV Integration
+    * Single combined enrollment & payment CSV file \- daily batch (Oscar Inbound)
+        * Payment instrument details (bank account information) is passed to Oscar with the enrollment data and binder payments and auto-payments are automatically enabled.
+* Oscar CSV Acknowledgement file \- daily (Oscar Outbound)
     * Oscar CSV Enrollment Status file (Oscar Outbound)
 
 Both implementations include error handling and both automated and manual reconciliation flows managed by our operations teams.


### PR DESCRIPTION
## Description

A few changes

1. Fix references to csv_implement.cmd
2. Update csv validator to no longer rely on "change" event and instead rely on pressing "Validate CSV" button
3. Add exact iso date format pattern for `date_signed` field

## Testing

**Integrating with Oscar guide has correct link to csv implementation guide**

<img width="1289" height="872" alt="image" src="https://github.com/user-attachments/assets/47a82fbc-3a7b-4844-8d2c-3144798bfdb6" />

**CSV Validator always requires you to press "Validate CSV" button

Nothing happens when file is uploaded
<img width="905" height="623" alt="image" src="https://github.com/user-attachments/assets/742c4bd7-3583-4552-becc-88b59f081292" />

CSV is valid after button click

<img width="1071" height="715" alt="image" src="https://github.com/user-attachments/assets/317b4bb3-e733-4305-85fc-49614bf673ac" />

Cannot provide both file and text area for validator

<img width="960" height="623" alt="image" src="https://github.com/user-attachments/assets/76a51feb-02e5-4c63-b9a2-79f0404b7067" />







**date_signed field has exact format** 

**date_signed field has exact format** 
<img width="1002" height="90" alt="image" src="https://github.com/user-attachments/assets/61652987-09aa-43d7-a148-ff0d53fde40b" />
